### PR TITLE
Router's context's locale not set during I18nRouter::match()

### DIFF
--- a/Router/I18nRouter.php
+++ b/Router/I18nRouter.php
@@ -144,7 +144,13 @@ class I18nRouter extends Router
     public function match($url)
     {
         if ($this->hostMap && null === $this->context->getParameter('_locale')) {
-            $this->context->setParameter('_locale', $this->container->get('request')->getSession()->getLocale());
+            $request = $this->container->get('request');
+            if (method_exists($request, 'getLocale')) {
+                $locale = $request->getLocale();
+            } else {
+                $locale = $request->getSession()->getLocale();
+            }
+            $this->context->setParameter('_locale', $locale);
         }
 
         $params = $this->getMatcher()->match($url);

--- a/Tests/Router/I18nRouterTest.php
+++ b/Tests/Router/I18nRouterTest.php
@@ -263,6 +263,28 @@ class I18nRouterTest extends \PHPUnit_Framework_TestCase
         $router->match('/english');
     }
 
+    /**
+     * @expectedException Symfony\Component\Routing\Exception\ResourceNotFoundException
+     * @expectedExceptionMessage The route "news_overview" is not available on the current host "uk.test", but only on these hosts "nl.test, be.test".
+     */
+    public function testMatchThrowsResourceNotFoundWhenContextLocaleNotSetAndPatternOfDifferentLocale()
+    {
+        $router = $this->getNonRedirectingHostMapRouter();
+
+        $router->match('/nieuws');
+    }
+
+    /**
+     * @expectedException Symfony\Component\Routing\Exception\ResourceNotFoundException
+     * @expectedExceptionMessage The route "dutch_only" is not available on the current host "uk.test", but only on these hosts "nl.test, be.test".
+     */
+    public function testMatchThrowsResourceNotFoundWhenContextLocaleNotSetAndPatternNotActive()
+    {
+        $router = $this->getNonRedirectingHostMapRouter();
+
+        $router->match('/dutch-only');
+    }
+
     private function getRouter($config = 'routing.yml', $translator = null, $redirectToHost = true)
     {
         $container = new Container();
@@ -291,6 +313,13 @@ class I18nRouterTest extends \PHPUnit_Framework_TestCase
     private function getNonRedirectingHostMapRouter($config = 'routing.yml') {
         $container = new Container();
         $container->set('routing.loader', new YamlFileLoader(new FileLocator(__DIR__.'/Fixture')));
+
+        $requestMock = $this->getMock('Symfony\Component\HttpFoundation\Request');
+        $requestMock
+            ->expects($this->any())
+            ->method('getLocale')
+            ->will($this->returnValue('en_UK'));
+        $container->set('request', $requestMock);
 
         $translator = new Translator('en_UK', new MessageSelector());
         $translator->setFallbackLocale('en');


### PR DESCRIPTION
When the match function is called the context's locale is not yet set. (It IS set when generate is called)

When the hostMap is used this results in two types of unwanted behaviour:
Patterns are matched when the corresponding route is turned off for the host.
Patterns are matched when the corresponding route is active for the host, but the pattern does not match the host's locale.

Note that none of the testcases failed because during all the tests the context's locale was set.

Earlier @schmittjoh mentioned the following:

---

The locale detection part should ideally be refactored along the lines of:
http://static.springsource.org/spring/docs/3.0.x/javadoc-api/org/springframework/web/servlet/i18n/package-summary.html

Don't know when I'll have time for that, so if someone else wants to take a stab feel free.

---

As I myself haven't got time for this refactor either I decided to make a hotfix PR to fix the issue described above.
