### PR TITLE
Fix locale detection for internal routes

### DIFF
--- a/Router/I18nRouter.php
+++ b/Router/I18nRouter.php
@@ -224,6 +224,16 @@ class I18nRouter extends Router
             );
         }
 
+        // if we have no locale set on the route, we try to set one according to the localeResolver
+        // if we don't do this all _internal routes will have the default locale on first request
+        if (!isset($params['_locale'])
+            && $this->container->isScopeActive('request')) {
+            $params['_locale'] = $this->localeResolver->resolveLocale(
+                $this->container->get('request'),
+                $this->container->getParameter('jms_i18n_routing.locales')
+            );
+        }
+
         return $params;
     }
 


### PR DESCRIPTION
We use a hostMap based approach for the routing (I'm a collegue of @fritsjanb). When hitting some pages with a fresh browser session, suddenly all subrequests would fail while generating urls (No route 'x' for locale 'en'). After some digging I found out that at some pages internal requests would somehow always get the fallback locale set. 

On the failing pages we cache the complete page for a period of time using varnish and esi, and only small parts of the page are not cached (the userbox). Because the complete page itself is cached, the first request to the Symfony backend with a fresh session would be a request on an `_internal` route, which has no locale..

This PR fixes the issue by setting the locale according to the host when the route has no locale available. With this fix the `_internal` routes will have the right locale.

I think this PR replaces #36.
