### PR TITLE
Added TranslationLocale and TranslationLanguage Form Types

### DIFF
--- a/Form/Extension/Type/TranslationLanguageType.php
+++ b/Form/Extension/Type/TranslationLanguageType.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Copyright 2012 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Alberto Aldegheri <albyrock87+dev[at]gmail.com>
+ */
+namespace JMS\I18nRoutingBundle\Form\Extension\Type;
+
+use JMS\I18nRoutingBundle\Router\LocaleResolverInterface;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Locale\Locale;
+
+class TranslationLanguageType extends AbstractType
+{
+    private $defaultLocale;
+    private $locales;
+
+    public function __construct($defaultLocale, array $locales, LocaleResolverInterface $resolver)
+    {
+        $this->defaultLocale = $resolver->getCurrentLocale() ?: $defaultLocale;
+        // flip the array for later intersection
+        $this->locales = array_flip($locales);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $choices = Locale::getDisplayLanguages($this->defaultLocale);
+        $choices = array_intersect_key($choices, $this->locales);
+        $resolver->setDefaults(array(
+            'choices' => $choices,
+            'preferred_choices' => array($this->defaultLocale)
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'choice';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'translation_language';
+    }
+}

--- a/Form/Extension/Type/TranslationLocaleType.php
+++ b/Form/Extension/Type/TranslationLocaleType.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Copyright 2012 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Alberto Aldegheri <albyrock87+dev[at]gmail.com>
+ */
+namespace JMS\I18nRoutingBundle\Form\Extension\Type;
+
+use JMS\I18nRoutingBundle\Router\LocaleResolverInterface;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Locale\Locale;
+
+class TranslationLocaleType extends AbstractType
+{
+    private $defaultLocale;
+    private $locales;
+
+    public function __construct($defaultLocale, array $locales, LocaleResolverInterface $resolver)
+    {
+        $this->defaultLocale = $resolver->getCurrentLocale() ?: $defaultLocale;
+        // flip the array for later intersection
+        $this->locales = array_flip($locales);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $choices = Locale::getDisplayLocales($this->defaultLocale);
+        $choices = array_intersect_key($choices, $this->locales);
+        $resolver->setDefaults(array(
+            'choices' => $choices,
+            'preferred_choices' => array($this->defaultLocale)
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return 'choice';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'translation_locale';
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,6 +16,9 @@
         <parameter key="jms_i18n_routing.cookie_setting_listener.class">JMS\I18nRoutingBundle\EventListener\CookieSettingListener</parameter>
         
         <parameter key="jms_i18n_routing.route_translation_extractor.class">JMS\I18nRoutingBundle\Translation\RouteTranslationExtractor</parameter>
+
+        <parameter key="jms_i18n_routing.form.translation_language.class">JMS\I18nRoutingBundle\Form\Extension\Type\TranslationLanguageType</parameter>
+        <parameter key="jms_i18n_routing.form.translation_locale.class">JMS\I18nRoutingBundle\Form\Extension\Type\TranslationLocaleType</parameter>
     </parameters>
 
     <services>
@@ -35,6 +38,20 @@
             <call method="setRedirectToHost">
                 <argument>%jms_i18n_routing.redirect_to_host%</argument>
             </call>
+        </service>
+
+        <service id="form.type.translation_language" class="%jms_i18n_routing.form.translation_language.class%" public="true">
+            <argument>%jms_i18n_routing.default_locale%</argument>
+            <argument>%jms_i18n_routing.locales%</argument>
+            <argument type="service" id="jms_i18n_routing.locale_resolver" />
+            <tag name="form.type" alias="translation_language" />
+        </service>
+
+        <service id="form.type.translation_locale" class="%jms_i18n_routing.form.translation_locale.class%" public="true">
+            <argument>%jms_i18n_routing.default_locale%</argument>
+            <argument>%jms_i18n_routing.locales%</argument>
+            <argument type="service" id="jms_i18n_routing.locale_resolver" />
+            <tag name="form.type" alias="translation_locale" />
         </service>
         
         <service id="jms_i18n_routing.locale_choosing_listener" class="%jms_i18n_routing.locale_choosing_listener.class%" public="false">

--- a/Router/LocaleResolverInterface.php
+++ b/Router/LocaleResolverInterface.php
@@ -23,4 +23,12 @@ interface LocaleResolverInterface
      *                        return a locale which is not available for the matched route
      */
     function resolveLocale(Request $request, array $availableLocales);
+
+    /**
+     * Returns the locale used in this request based on a previous call to resolveLocale method
+     *
+     * @return string|null may return null if no suitable locale is found, may also
+     *                        return a locale which is not available for the matched route
+     */
+    function getCurrentLocale();
 }


### PR DESCRIPTION
Form Types are compatible with Symfony 2.1 only.
Those Field Types are ChoiceType and they contain only routing languages with current language as default.

``` php
<?php
->add('my_locale_field', 'translation_locale', array(
            'label' => 'Choose your favourite locale'
            ))
// or
->add('my_language_field', 'translation_language', array(
            'label' => 'Choose your favourite language'
            ))
```
