### PR TITLE
Changed hostmap into a container parameter

### DIFF
--- a/DependencyInjection/JMSI18nRoutingExtension.php
+++ b/DependencyInjection/JMSI18nRoutingExtension.php
@@ -58,9 +58,10 @@ class JMSI18nRoutingExtension extends Extension
         }
 
         if ($config['hosts']) {
+            $container->setParameter('jms_i18n_routing.hostmap', $config['hosts']);
             $container
                 ->getDefinition('jms_i18n_routing.router')
-                ->addMethodCall('setHostMap', array($config['hosts']))
+                ->addMethodCall('setHostMap', array('%jms_i18n_routing.hostmap%'))
             ;
 
             $container


### PR DESCRIPTION
The hostmap is injected into the I18nRouter through JMSI18nRoutingExtension. 

By creating a container parameter it can be easily injected into other services when required. 
