### PR TITLE
Do not set the "hl" cookie if the response is an error, as the locale ma...

### DIFF
--- a/EventListener/CookieSettingListener.php
+++ b/EventListener/CookieSettingListener.php
@@ -35,7 +35,8 @@ class CookieSettingListener
 
     public function onKernelResponse(FilterResponseEvent $event)
     {
-        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+        //Check if the current response contains an error. If it does, do not set the cookie as the Locale may not be properly set
+        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType() || !($event->getResponse()->isSuccessful() || $event->getResponse()->isRedirection())) {
             return;
         }
 

--- a/Tests/Functional/PrefixStrategyTest.php
+++ b/Tests/Functional/PrefixStrategyTest.php
@@ -57,4 +57,18 @@ class PrefixStrategyTest extends BaseTestCase
         $this->assertSame(2, count($cookies));
         $this->assertSame('de', $cookies[0]->getValue());
     }
+
+    public function testNoCookieOnError()
+    {
+        $client = $this->createClient(array('config' => 'strategy_prefix.yml'));
+        $client->insulate();
+
+        $client->request('GET', '/nonexistent');
+
+        $response = $client->getResponse();
+        $this->assertTrue($response->isClientError(), (string) $response);
+
+        $cookies = $response->headers->getCookies();
+        $this->assertSame(1, count($cookies));
+    }
 }


### PR DESCRIPTION
...y not be properly set, thus rendering the cookie useless-

I check only if the response is a 200 status code (isOk method). Is there any other case where a cookie should be set?

As said in #45
