### PR TITLE
Forward the query string when redirecting to the locale prefix.

### DIFF
--- a/EventListener/LocaleChoosingListener.php
+++ b/EventListener/LocaleChoosingListener.php
@@ -69,6 +69,16 @@ class LocaleChoosingListener
 
         $locale = $this->localeResolver->resolveLocale($request, $this->locales) ?: $this->defaultLocale;
         $request->setLocale($locale);
-        $event->setResponse(new RedirectResponse($request->getBaseUrl().'/'.$locale.'/'));
+
+        $qs = $request->getQueryString();
+        //The hl param does not need to be forwarded
+        if ($request->query->has('hl')) {
+            $qs = preg_replace('#hl=[^&]*#', '', $qs);
+        }
+        if (!empty($qs)) {
+            $qs = '?'.$qs;
+        }
+
+        $event->setResponse(new RedirectResponse($request->getBaseUrl().'/'.$locale.'/'.$qs));
     }
 }

--- a/Tests/Functional/PrefixStrategyTest.php
+++ b/Tests/Functional/PrefixStrategyTest.php
@@ -30,8 +30,8 @@ class PrefixStrategyTest extends BaseTestCase
         ));
         $client->insulate();
 
-        $client->request('GET', '/');
-        $this->assertTrue($client->getResponse()->isRedirect('/'.$expectedLocale.'/'), (string) $client->getResponse());
+        $client->request('GET', '/?extra=params');
+        $this->assertTrue($client->getResponse()->isRedirect('/'.$expectedLocale.'/?extra=params'), (string) $client->getResponse());
     }
 
     public function getLocaleChoosingTests()


### PR DESCRIPTION
Extra query strings (imagine for example the (in)famous utmz_*) should also be forwarded,
otherwise they are lost when being redirected to the proper locale prefix. The "hl" param
should not be forwarded.
