### PR TITLE
Correction to unit test #90 - testLanguageCookieIsSet

### DIFF
--- a/Tests/Functional/PrefixStrategyTest.php
+++ b/Tests/Functional/PrefixStrategyTest.php
@@ -54,7 +54,7 @@ class PrefixStrategyTest extends BaseTestCase
         $this->assertTrue($response->isRedirect('/de/'), (string) $response);
 
         $cookies = $response->headers->getCookies();
-        $this->assertSame(2, count($cookies));
+        $this->assertCount(1, array_filter($cookies, function($item) { return ($item->getName() == 'hl')? true : false; }), "Expected a single cookie to contain hl");
         $this->assertSame('de', $cookies[0]->getValue());
     }
 

--- a/Tests/Functional/PrefixStrategyTest.php
+++ b/Tests/Functional/PrefixStrategyTest.php
@@ -54,7 +54,7 @@ class PrefixStrategyTest extends BaseTestCase
         $this->assertTrue($response->isRedirect('/de/'), (string) $response);
 
         $cookies = $response->headers->getCookies();
-        $this->assertCount(1, array_filter($cookies, function($item) { return ($item->getName() == 'hl')? true : false; }), "Expected a single cookie to contain hl");
+        $this->assertCount(1, array_filter($cookies, function($item) { return $item->getName() == 'hl'; }), "Expected a single cookie to contain hl");
         $this->assertSame('de', $cookies[0]->getValue());
     }
 


### PR DESCRIPTION
```
1) JMS\I18nRoutingBundle\Tests\Functional\PrefixStrategyTest::testLanguageCookieIsSet
Failed asserting that 1 is identical to 2.

/var/www/JMSI18nRoutingBundle/Tests/Functional/PrefixStrategyTest.php:57
```