### PR TITLE
Locale detection bug for custom strategy in Symfony 2.3

### DIFF
--- a/Router/I18nRouter.php
+++ b/Router/I18nRouter.php
@@ -169,8 +169,7 @@ class I18nRouter extends Router
                 $params['_route'] = substr($params['_route'], $pos + strlen(I18nLoader::ROUTING_PREFIX));
             }
 
-            if (!($currentLocale = $this->context->getParameter('_locale'))
-                    && $this->container->isScopeActive('request')) {
+            if ($this->container->isScopeActive('request')) {
                 $currentLocale = $this->localeResolver->resolveLocale(
                     $this->container->get('request'), $params['_locales']);
 


### PR DESCRIPTION
Since Symfony 2.3 `_locale` parameter constantly persists in the parameters, it makes the bundle working incorrectly when `custom` strategy is used. This results redirects of all domains to a single domain.

Removing additional locale check fixes the issue (however, it may add some problems in other versions of Symfony).
