### PR TITLE
Added i18n_prefix option

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -41,7 +41,7 @@ Some examples below::
     <a href="{{ path("homepage", {"_locale": "en"}) }}">English</a>
     
 Leaving routes untranslated
--------------------------
+---------------------------
 If you don't want to translate a single given route, you can begin the route name with "_" (e.g. "_contact") or disable it in the routing configuration:
 
 .. code-block :: yaml
@@ -50,6 +50,17 @@ If you don't want to translate a single given route, you can begin the route nam
     homepage:
         ...
         options: { i18n: false }
+
+Prefixing routes before the _locale
+-----------------------------------
+If you want to add a prefix before the _locale string (e.g. /admin/en/dashboard), you can add the "i18n_prefix" option.
+
+.. code-block :: yaml
+
+    # app/config/routing.yml
+    dashboard:
+        ...
+        options: { i18n_prefix: admin }
 
 More Resources
 --------------

--- a/Router/DefaultPatternGenerationStrategy.php
+++ b/Router/DefaultPatternGenerationStrategy.php
@@ -51,6 +51,9 @@ class DefaultPatternGenerationStrategy implements PatternGenerationStrategyInter
             if (self::STRATEGY_PREFIX === $this->strategy
                     || (self::STRATEGY_PREFIX_EXCEPT_DEFAULT === $this->strategy && $this->defaultLocale !== $locale)) {
                 $i18nPattern = '/'.$locale.$i18nPattern;
+                if (null !== $route->getOption('i18n_prefix')) {
+                    $i18nPattern = $route->getOption('i18n_prefix').$i18nPattern;
+                }
             }
 
             $patterns[$i18nPattern][] = $locale;

--- a/Tests/Router/I18nLoaderTest.php
+++ b/Tests/Router/I18nLoaderTest.php
@@ -128,6 +128,16 @@ class I18nLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/contact', $en->getPattern());
     }
 
+    public function testLoadAddsPrefix()
+    {
+        $col = new RouteCollection();
+        $col->add('dashboard', new Route('/dashboard', array(), array(), array('i18n_prefix' => '/admin')));
+        $i18nCol = $this->getLoader('prefix')->load($col);
+
+        $en = $i18nCol->get('en__RG__dashboard');
+        $this->assertEquals('/admin/en/dashboard', $en->getPattern());
+    }
+
     public function getStrategies()
     {
         return array(array('custom'), array('prefix'), array('prefix_except_default'));


### PR DESCRIPTION
By adding the i18n_prefix option to a route, you can prefix said route with the given string. The prefix is added before the _locale string. 

E.g. the following will result in an `/admin/en/dashboard` uri. 

```
dashboard:
    path: /dashboard
    options: { i18n_prefix: /admin }
```
