### PR TITLE
Updated LocaleChoosingListener

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -43,6 +43,7 @@
             <argument>%jms_i18n_routing.default_locale%</argument>
             <argument>%jms_i18n_routing.locales%</argument>
             <argument type="service" id="jms_i18n_routing.locale_resolver" />
+            <argument type="service" id="router" />
         </service>
         
         <service id="jms_i18n_routing.cookie_setting_listener" class="%jms_i18n_routing.cookie_setting_listener.class%" public="false" />

--- a/Tests/Functional/PrefixStrategyTest.php
+++ b/Tests/Functional/PrefixStrategyTest.php
@@ -34,6 +34,20 @@ class PrefixStrategyTest extends BaseTestCase
         $this->assertTrue($client->getResponse()->isRedirect('/'.$expectedLocale.'/?extra=params'), (string) $client->getResponse());
     }
 
+    /**
+     * @dataProvider getLocaleChoosingTests
+     */
+    public function testLocaleIsChoosenWhenPrefixedPageIsRequested($acceptLanguages, $expectedLocale)
+    {
+        $client = $this->createClient(array('config' => 'strategy_prefix.yml'), array(
+            'HTTP_ACCEPT_LANGUAGE' => $acceptLanguages,
+        ));
+        $client->insulate();
+
+        $client->request('GET', '/prefix?extra=params');
+        $this->assertTrue($client->getResponse()->isRedirect('/prefix/'.$expectedLocale.'/?extra=params'), (string) $client->getResponse());
+    }
+
     public function getLocaleChoosingTests()
     {
         return array(

--- a/Tests/Functional/TestBundle/Controller/DefaultController.php
+++ b/Tests/Functional/TestBundle/Controller/DefaultController.php
@@ -37,4 +37,16 @@ class DefaultController
 
         return array('locale' => $locale);
     }
+
+    /**
+     * @Route("/", name = "prefixPage", options={"i18n_prefix": "/prefix"})
+     * @Template
+     */
+    public function prefixAction(Request $request)
+    {
+        $locale = method_exists($request, 'getLocale') ? $request->getLocale()
+            : $request->getSession()->getLocale();
+
+        return array('locale' => $locale);
+    }
 }


### PR DESCRIPTION
This PR ties in with my previous one, introducing the i18n_prefix option. When requesting `example.com/` the bundle would redirect to `example.com/en/` (or the most appropriate locale). However, it didn't do so when requesting `example.com/i18n_prefix/`. 

The listener will now check if the requested path is a "landing" path that matches `''` or any of the prefixes used. If so, it redirects to the correct url with the necessary locale.
