### PR TITLE
Allow "false" strings from xml route config

### DIFF
--- a/Router/DefaultRouteExclusionStrategy.php
+++ b/Router/DefaultRouteExclusionStrategy.php
@@ -38,7 +38,7 @@ class DefaultRouteExclusionStrategy implements RouteExclusionStrategyInterface
             return true;
         }
 
-        if (false === $route->getOption('i18n')) {
+        if (false === $route->getOption('i18n') || 'false' === $route->getOption('i18n')) {
             return true;
         }
 


### PR DESCRIPTION
In XML the <option> parameter will return a string, so this needs to be checked aswell.
