### PR TITLE
Improved locale resolver — Added accept_header_languages option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -114,6 +114,7 @@ final class Configuration implements ConfigurationInterface
                             ->booleanNode('httponly')->defaultFalse()->end()
                         ->end()
                     ->end()
+                    ->booleanNode('accept_header_languages')->defaultTrue()->end()
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/JMSI18nRoutingExtension.php
+++ b/DependencyInjection/JMSI18nRoutingExtension.php
@@ -45,6 +45,7 @@ class JMSI18nRoutingExtension extends Extension
         $container->setParameter('jms_i18n_routing.strategy', $config['strategy']);
         $container->setParameter('jms_i18n_routing.redirect_to_host', $config['redirect_to_host']);
         $container->setParameter('jms_i18n_routing.cookie.name', $config['cookie']['name']);
+        $container->setParameter('jms_i18n_routing.accept_header_languages', $config['accept_header_languages']);
 
         $this->addClassesToCompile(array(
             $container->getDefinition('jms_i18n_routing.router')->getClass(),

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -21,6 +21,7 @@
     <services>
         <service id="jms_i18n_routing.locale_resolver.default" class="%jms_i18n_routing.locale_resolver.class%" public="false">
             <argument>%jms_i18n_routing.cookie.name%</argument>
+            <argument>%jms_i18n_routing.accept_header_languages%</argument>
         </service>
         <service id="jms_i18n_routing.locale_resolver" alias="jms_i18n_routing.locale_resolver.default" public="false" />
         

--- a/Router/DefaultLocaleResolver.php
+++ b/Router/DefaultLocaleResolver.php
@@ -22,10 +22,11 @@ class DefaultLocaleResolver implements LocaleResolverInterface
     private $cookieName;
     private $hostMap;
 
-    public function __construct($cookieName, array $hostMap = array())
+    public function __construct($cookieName, $acceptHeaderLanguages = true, array $hostMap = array())
     {
         $this->cookieName = $cookieName;
         $this->hostMap = $hostMap;
+        $this->acceptHeaderLanguages = $acceptHeaderLanguages;
     }
 
     /**
@@ -64,7 +65,7 @@ class DefaultLocaleResolver implements LocaleResolverInterface
         }
 
         // use accept header for locale matching if sent
-        if ($languages = $request->getLanguages()) {
+        if (true == $this->acceptHeaderLanguages && $languages = $request->getLanguages()) {
             foreach ($languages as $lang) {
                 if (in_array($lang, $availableLocales, true)) {
                     return $lang;


### PR DESCRIPTION
By adding `accept_header_languages` to your config file you can enable or disable resolving locale based on Accept-Language header, so this will be helpful if you want to use `default_language` option instead of guessing user language.

Related Issue: #68
