### PR TITLE
Added sticky_i18n_prefix option for i18n_prefix

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -4,7 +4,7 @@ Usage
 Introduction
 ------------
 You can continue to create routes like you would do normally. In fact,
-during development you don't need to make any special changes to your existing 
+during development you don't need to make any special changes to your existing
 routes to make them translatable.
 
 Translating Routes
@@ -15,7 +15,7 @@ command that is provided by JMSTranslationBundle_:
 .. code-block :: bash
 
     $ php app/console translation:extract de --enable-extractor=jms_i18n_routing # ...
-    
+
 Please refer to the `bundle's documentation`_ for more information.
 
 .. _JMSTranslationBundle: https://github.com/schmittjoh/JMSTranslationBundle
@@ -34,12 +34,12 @@ Some examples below::
 
     <!-- uses locale of the request context to generate the route -->
     <a href="{{ path("contact") }}">Contact</a>
-    
+
     <!-- sometimes it's necessary to generate routes for a locale other than that
          of the request context, then you can pass it explicitly -->
     <a href="{{ path("homepage", {"_locale": "de"}) }}">Deutsch</a>
     <a href="{{ path("homepage", {"_locale": "en"}) }}">English</a>
-    
+
 Leaving routes untranslated
 ---------------------------
 If you don't want to translate a single given route, you can begin the route name with "_" (e.g. "_contact") or disable it in the routing configuration:
@@ -62,12 +62,22 @@ If you want to add a prefix before the _locale string (e.g. /admin/en/dashboard)
         ...
         options: { i18n_prefix: admin }
 
+
+If you are using the "prefix_except_default" strategy and want the prefix to be kept for the default locale (e.g. /admin/dashboard), you can set the "sticky_i18n_prefix" to true.
+
+.. code-block:: yaml
+
+    # app/config/routing.yml
+    dashboard:
+        ...
+        options: { i18n_prefix: admin, sticky_i18n_prefix: true }
+
 More Resources
 --------------
 
 .. toctree ::
     :hidden:
-    
+
     /cookbook/language_switcher
-    
+
 - :doc:`Creating a Language Switcher </cookbook/language_switcher>`

--- a/Router/DefaultPatternGenerationStrategy.php
+++ b/Router/DefaultPatternGenerationStrategy.php
@@ -44,7 +44,7 @@ class DefaultPatternGenerationStrategy implements PatternGenerationStrategyInter
     {
         $patterns = array();
         foreach ($route->getOption('i18n_locales') ?: $this->locales as $locale) {
-            // Check if translation exists in the translation catalogue to avoid errors being logged by 
+            // Check if translation exists in the translation catalogue to avoid errors being logged by
             // the new LoggingTranslator of Symfony 2.6. However, the LoggingTranslator did not implement
             // the interface until Symfony 2.6.5, so an extra check is needed.
             if ($this->translator instanceof TranslatorBagInterface || $this->translator instanceof LoggingTranslator) {
@@ -70,6 +70,11 @@ class DefaultPatternGenerationStrategy implements PatternGenerationStrategyInter
                 if (null !== $route->getOption('i18n_prefix')) {
                     $i18nPattern = $route->getOption('i18n_prefix').$i18nPattern;
                 }
+            }
+            else if ((self::STRATEGY_PREFIX_EXCEPT_DEFAULT === $this->strategy && $this->defaultLocale === $locale)
+                     && (true === $route->getOption('sticky_18n_prefix'))
+                     && (null !== $route->getOption('i18n_prefix'))) {
+                $i18nPattern = $route->getOption('i18n_prefix').$i18nPattern;
             }
 
             $patterns[$i18nPattern][] = $locale;


### PR DESCRIPTION
@Brammm 's `i18n_prefix` is great but has a small issue when you use it along `prefix_except_default` strategy as the prefix is also removed from the path for the default locale, which can be problematic for security settings (firewalls and access control).

I added a `sticky_i18n_prefix` (not sure the name is great) that can be set to true so that the prefix is in the path no matter what (`en` is the default locale in this example):

```
dashboard:
    path: /dashboard
    options: { i18n_prefix: /admin }
```
Route for `en` locale: `/dashboard`


```
dashboard:
    path: /dashboard
    options: { i18n_prefix: /admin, sticky_i18n_prefix: true }
```
Route for `en` locale: `/admin/dashboard`

