### PR TITLE
Make JMSTranslationBundle an optional dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "symfony/framework-bundle": "~2.1",
-        "jms/translation-bundle": "~1.0"
+        "symfony/framework-bundle": "~2.1"
     },
     "require-dev": {
         "symfony/framework-bundle": "<2.1.5",
@@ -33,6 +32,9 @@
         "sensio/framework-extra-bundle": "<2.1.5",
         "jms/di-extra-bundle": "*"
     },
+    "suggest": {
+        "jms/translation-bundle": "If you want to use the RouteTranslation extractor"
+    }
     "autoload": {
         "psr-0": { "JMS\\I18nRoutingBundle": "" }
     },


### PR DESCRIPTION
The JMSTranslationBundle is only needed if you want to use the bundled extractor. If you don't need the extractor you're being forced to download a bunch of packages that are not really useful and may clash with other dependencies (I am thinking of the php-parser the translation bundle needs). The code doesn't need any more changes because the bundle extension already checks for the presence of the JMSTranslationBundle before registering the extractor.