### PR TITLE
Make sure to add hreflang on localized pages. 

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,6 +16,7 @@
         <parameter key="jms_i18n_routing.cookie_setting_listener.class">JMS\I18nRoutingBundle\EventListener\CookieSettingListener</parameter>
         
         <parameter key="jms_i18n_routing.route_translation_extractor.class">JMS\I18nRoutingBundle\Translation\RouteTranslationExtractor</parameter>
+        <parameter key="jms_i18n_routing.twig_extension.class">JMS\I18nRoutingBundle\Twig\I18nRoutingExtension</parameter>
     </parameters>
 
     <services>
@@ -68,6 +69,12 @@
             <argument type="service" id="router" />
             <argument type="service" id="jms_i18n_routing.route_exclusion_strategy" />
             <tag name="jms_translation.extractor" alias="jms_i18n_routing" />
+        </service>
+
+        <service id="jms_i18n_routing.twig_extension" class="%jms_i18n_routing.twig_extension.class%" public="false">
+            <argument type="service" id="request_stack" />
+            <argument>%jms_i18n_routing.locales%</argument>
+            <tag name="twig.extension" />
         </service>
     </services>
 </container>

--- a/Resources/views/hreflang.html.twig
+++ b/Resources/views/hreflang.html.twig
@@ -1,0 +1,5 @@
+
+{% for locale in locales %}
+    {% set arr = routeParams|merge({'_locale':locale}) %}
+    <link rel="alternate" hreflang="{{ locale }}" href="{{ url(route, arr) }}" />
+{% endfor %}

--- a/Router/DefaultPatternGenerationStrategy.php
+++ b/Router/DefaultPatternGenerationStrategy.php
@@ -51,7 +51,7 @@ class DefaultPatternGenerationStrategy implements PatternGenerationStrategyInter
                 // Check if route is translated.
                 if (!$this->translator->getCatalogue($locale)->has($routeName, $this->translationDomain)) {
                     // No translation found.
-                    $i18nPattern = $route->getPattern();
+                    $i18nPattern = $route->getPath();
                 } else {
                     // Get translation.
                     $i18nPattern = $this->translator->trans($routeName, array(), $this->translationDomain, $locale);
@@ -59,7 +59,7 @@ class DefaultPatternGenerationStrategy implements PatternGenerationStrategyInter
             } else {
                 // if no translation exists, we use the current pattern
                 if ($routeName === $i18nPattern = $this->translator->trans($routeName, array(), $this->translationDomain, $locale)) {
-                    $i18nPattern = $route->getPattern();
+                    $i18nPattern = $route->getPath();
                 }
             }
 

--- a/Router/I18nLoader.php
+++ b/Router/I18nLoader.php
@@ -61,14 +61,14 @@ class I18nLoader
                 // We still add individual routes for each locale afterwards for faster generation.
                 if (count($locales) > 1) {
                     $catchMultipleRoute = clone $route;
-                    $catchMultipleRoute->setPattern($pattern);
+                    $catchMultipleRoute->setPath($pattern);
                     $catchMultipleRoute->setDefault('_locales', $locales);
                     $i18nCollection->add(implode('_', $locales).I18nLoader::ROUTING_PREFIX.$name, $catchMultipleRoute);
                 }
 
                 foreach ($locales as $locale) {
                     $localeRoute = clone $route;
-                    $localeRoute->setPattern($pattern);
+                    $localeRoute->setPath($pattern);
                     $localeRoute->setDefault('_locale', $locale);
                     $i18nCollection->add($locale.I18nLoader::ROUTING_PREFIX.$name, $localeRoute);
                 }

--- a/Tests/Router/I18nRouterTest.php
+++ b/Tests/Router/I18nRouterTest.php
@@ -294,7 +294,7 @@ class I18nRouterTest extends \PHPUnit_Framework_TestCase
 
         if (null === $translator) {
             $translator = new Translator('en', new MessageSelector());
-            $translator->setFallbackLocale('en');
+            $translator->setFallbackLocales(array('en'));
             $translator->addLoader('yml', new TranslationLoader());
             $translator->addResource('yml', file_get_contents(__DIR__.'/Fixture/routes.de.yml'), 'de', 'routes');
             $translator->addResource('yml', file_get_contents(__DIR__.'/Fixture/routes.en.yml'), 'en', 'routes');
@@ -321,7 +321,7 @@ class I18nRouterTest extends \PHPUnit_Framework_TestCase
         $container->set('routing.loader', new YamlFileLoader(new FileLocator(__DIR__.'/Fixture')));
 
         $translator = new Translator('en_UK', new MessageSelector());
-        $translator->setFallbackLocale('en');
+        $translator->setFallbackLocales(array('en'));
         $translator->addLoader('yml', new TranslationLoader());
         $translator->addResource('yml', file_get_contents(__DIR__.'/Fixture/routes.en_UK.yml'), 'en_UK', 'routes');
         $translator->addResource('yml', file_get_contents(__DIR__.'/Fixture/routes.en_US.yml'), 'en_US', 'routes');

--- a/Translation/RouteTranslationExtractor.php
+++ b/Translation/RouteTranslationExtractor.php
@@ -57,7 +57,7 @@ class RouteTranslationExtractor implements ExtractorInterface
             }
 
             $message = new Message($name, $this->domain);
-            $message->setDesc($route->getPattern());
+            $message->setDesc($route->getPath());
             $catalogue->add($message);
         }
 

--- a/Twig/I18nRoutingExtension.php
+++ b/Twig/I18nRoutingExtension.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace JMS\I18nRoutingBundle\Twig;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @author Tobias Nyholm
+ */
+class I18nRoutingExtension extends \Twig_Extension
+{
+    /**
+     * @var RequestStack requestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var array locales
+     */
+    private $locales;
+
+    /**
+     * @param RequestStack $requestStack
+     * @param array        $locales
+     */
+    public function __construct(RequestStack $requestStack, $locales)
+    {
+        $this->requestStack = $requestStack;
+        $this->locales = $locales;
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('hreflang', array($this, 'getHreflang'), array(
+                'needs_environment'=>true,
+                'is_safe'=>array('html'),
+                )),
+        );
+    }
+
+    /**
+     * Return HTML with hreflang attributes
+     *
+     * @param \Twig_Environment $env
+     */
+    public function getHreflang(\Twig_Environment $env)
+    {
+        $request = $this->requestStack->getMasterRequest();
+        $routeParams = $request->attributes->get('_route_params');
+        if (!isset($routeParams['localized']) || !$routeParams['localized']) {
+            return;
+        }
+
+        return $env->render('JMSI18nRoutingBundle::hreflang.html.twig', array(
+            'locales'=>$this->locales,
+            'route'=>$request->attributes->get('_route'),
+            'routeParams'=>$routeParams,
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'i18n_routing_extension';
+    }
+}


### PR DESCRIPTION
This introduces a twig function `hreflang` that will print `<link rel="alternate" hreflang="es" href="http://es.example.com/" />` on all pages that are localized. 

I do also remove calls to deprecated functions. 
