### PR TITLE
Allow host to be a regexp. useful for subdomains.

### DIFF
--- a/Router/DefaultLocaleResolver.php
+++ b/Router/DefaultLocaleResolver.php
@@ -37,6 +37,12 @@ class DefaultLocaleResolver implements LocaleResolverInterface
             return $this->hostMap[$host];
         }
 
+        foreach ($this->hostMap as $host => $locale) {
+            if ('/' === $host[0] && preg_match($host, $request->getHost())) {
+                return $locale;
+            }
+        }
+
         // if a locale has been specifically set as a query parameter, use it
         if ($request->query->has('hl')) {
             $hostLanguage = $request->query->get('hl');

--- a/Tests/Router/DefaultLocaleResolverTest.php
+++ b/Tests/Router/DefaultLocaleResolverTest.php
@@ -24,6 +24,7 @@ class DefaultLocaleResolverTest extends \PHPUnit_Framework_TestCase
         $tests = array();
 
         $tests[] = array(Request::create('http://foo/?hl=de'), array('foo'), 'en', 'Host has precedence before query parameter');
+        $tests[] = array(Request::create('http://bar.foo'), array('foo'), 'en', 'Host as regexp');
         $tests[] = array(Request::create('/?hl=de'), array('foo'), 'de', 'Query parameter is selected');
         $tests[] = array(Request::create('/?hl=de', 'GET', array(), array('hl' => 'en')), array('foo'), 'de', 'Query parameter has precedence before cookie');
 
@@ -63,6 +64,7 @@ class DefaultLocaleResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver = new DefaultLocaleResolver('hl', array(
             'foo' => 'en',
             'bar' => 'de',
+            '/.*\.foo/' => 'en'
         ));
     }
 }


### PR DESCRIPTION
It helps us to configure router once for all cases, dev, staging, prod etc

```yaml
jms_i18n_routing:
    default_locale: %locale%
    locales: ['sv', 'no']
    strategy: custom
    hosts:
        'sv': '/foo\.se|.*\.foo\.se/'
        'no': '/foo\.no|.*\.foo\.no/'
```