### PR TITLE
Deprecation suppressed.

### DIFF
--- a/Router/DefaultPatternGenerationStrategy.php
+++ b/Router/DefaultPatternGenerationStrategy.php
@@ -7,6 +7,7 @@ use Symfony\Component\Translation\LoggingTranslator;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * The default strategy supports 3 different scenarios, and makes use of the
@@ -44,14 +45,20 @@ class DefaultPatternGenerationStrategy implements PatternGenerationStrategyInter
     {
         $patterns = array();
         foreach ($route->getOption('i18n_locales') ?: $this->locales as $locale) {
-            // Check if translation exists in the translation catalogue to avoid errors being logged by 
+            // Check if translation exists in the translation catalogue to avoid errors being logged by
             // the new LoggingTranslator of Symfony 2.6. However, the LoggingTranslator did not implement
             // the interface until Symfony 2.6.5, so an extra check is needed.
             if ($this->translator instanceof TranslatorBagInterface || $this->translator instanceof LoggingTranslator) {
                 // Check if route is translated.
                 if (!$this->translator->getCatalogue($locale)->has($routeName, $this->translationDomain)) {
                     // No translation found.
-                    $i18nPattern = $route->getPattern();
+                    // getPattern is deprecated since Symfony 2.2 and will be removed in 3.0. Use the getPath() message suppressed.
+                    if (Kernel::VERSION > 2.2) {
+                        $i18nPattern = $route->getPath();
+                    }else {
+                        $i18nPattern = $route->getPattern();
+                    }
+
                 } else {
                     // Get translation.
                     $i18nPattern = $this->translator->trans($routeName, array(), $this->translationDomain, $locale);
@@ -59,7 +66,12 @@ class DefaultPatternGenerationStrategy implements PatternGenerationStrategyInter
             } else {
                 // if no translation exists, we use the current pattern
                 if ($routeName === $i18nPattern = $this->translator->trans($routeName, array(), $this->translationDomain, $locale)) {
-                    $i18nPattern = $route->getPattern();
+                    // getPattern is deprecated since Symfony 2.2 and will be removed in 3.0. Use the getPath() message suppressed.
+                    if (Kernel::VERSION > 2.2) {
+                        $i18nPattern = $route->getPath();
+                    }else {
+                        $i18nPattern = $route->getPattern();
+                    }
                 }
             }
 

--- a/Router/I18nLoader.php
+++ b/Router/I18nLoader.php
@@ -23,6 +23,7 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use JMS\I18nRoutingBundle\Util\RouteExtractor;
 use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * This loader expands all routes which are eligible for i18n.
@@ -61,14 +62,26 @@ class I18nLoader
                 // We still add individual routes for each locale afterwards for faster generation.
                 if (count($locales) > 1) {
                     $catchMultipleRoute = clone $route;
-                    $catchMultipleRoute->setPattern($pattern);
+                    // setPattern is deprecated since Symfony 2.2 and will be removed in 3.0. Use the setPath() message suppressed.
+                    if (Kernel::VERSION > 2.2) {
+                        $catchMultipleRoute->setPath($pattern);
+                    } else {
+                        $catchMultipleRoute->setPattern($pattern);
+                    }
+
                     $catchMultipleRoute->setDefault('_locales', $locales);
                     $i18nCollection->add(implode('_', $locales).I18nLoader::ROUTING_PREFIX.$name, $catchMultipleRoute);
                 }
 
                 foreach ($locales as $locale) {
                     $localeRoute = clone $route;
-                    $localeRoute->setPattern($pattern);
+                    // setPattern is deprecated since Symfony 2.2 and will be removed in 3.0. Use the setPath() message suppressed.
+                    if (Kernel::VERSION > 2.2) {
+                        $localeRoute->setPath($pattern);
+                    } else {
+                        $localeRoute->setPattern($pattern);
+                    }
+
                     $localeRoute->setDefault('_locale', $locale);
                     $i18nCollection->add($locale.I18nLoader::ROUTING_PREFIX.$name, $localeRoute);
                 }

--- a/Tests/Router/I18nLoaderTest.php
+++ b/Tests/Router/I18nLoaderTest.php
@@ -30,9 +30,20 @@ use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\IdentityTranslator;
 use JMS\I18nRoutingBundle\Router\I18nLoader;
 use JMS\I18nRoutingBundle\Router\I18nRouter;
+use Symfony\Component\HttpKernel\Kernel;
 
 class I18nLoaderTest extends \PHPUnit_Framework_TestCase
 {
+    // getPattern is deprecated since Symfony 2.2 and will be removed in 3.0. Use the getPath() message suppressed.
+    public function getPattern($lang)
+    {
+        if (Kernel::VERSION > 2.2) {
+            return $lang->getPath();
+        }
+
+        return $lang->getPattern();
+
+    }
     public function testLoad()
     {
         $col = new RouteCollection();
@@ -42,11 +53,11 @@ class I18nLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($i18nCol->all()));
 
         $de = $i18nCol->get('de__RG__contact');
-        $this->assertEquals('/kontakt', $de->getPattern());
+        $this->assertEquals('/kontakt', $this->getPattern($de));
         $this->assertEquals('de', $de->getDefault('_locale'));
 
         $en = $i18nCol->get('en__RG__contact');
-        $this->assertEquals('/contact', $en->getPattern());
+        $this->assertEquals('/contact', $this->getPattern($en));
         $this->assertEquals('en', $en->getDefault('_locale'));
     }
 
@@ -59,10 +70,10 @@ class I18nLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, count($i18nCol->all()));
 
         $de = $i18nCol->get('de__RG__support');
-        $this->assertEquals('/support', $de->getPattern());
+        $this->assertEquals('/support', $this->getPattern($de));
 
         $en = $i18nCol->get('en__RG__support');
-        $this->assertEquals('/support', $en->getPattern());
+        $this->assertEquals('/support', $this->getPattern($en));
     }
 
     /**
@@ -85,8 +96,8 @@ class I18nLoaderTest extends \PHPUnit_Framework_TestCase
         $i18nCol = $this->getLoader()->load($col);
 
         $this->assertEquals(3, count($i18nCol->all()));
-        $this->assertEquals('/not-translated', $i18nCol->get('de__RG__untranslated_route')->getPattern());
-        $this->assertEquals('/not-translated', $i18nCol->get('en__RG__untranslated_route')->getPattern());
+        $this->assertEquals('/not-translated', $this->getPattern($i18nCol->get('en__RG__untranslated_route')));
+        $this->assertEquals('/not-translated', $this->getPattern($i18nCol->get('en__RG__untranslated_route')));
     }
 
     public function testLoadIfRouteIsNotTranslatedToAllLocales()
@@ -107,10 +118,10 @@ class I18nLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($i18nCol->all()));
 
         $de = $i18nCol->get('de__RG__contact');
-        $this->assertEquals('/de/kontakt', $de->getPattern());
+        $this->assertEquals('/de/kontakt', $this->getPattern($de));
 
         $en = $i18nCol->get('en__RG__contact');
-        $this->assertEquals('/en/contact', $en->getPattern());
+        $this->assertEquals('/en/contact', $this->getPattern($en));
     }
 
     public function testLoadIfStrategyIsPrefixExceptDefault()
@@ -122,10 +133,10 @@ class I18nLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($i18nCol->all()));
 
         $de = $i18nCol->get('de__RG__contact');
-        $this->assertEquals('/de/kontakt', $de->getPattern());
+        $this->assertEquals('/de/kontakt', $this->getPattern($de));
 
         $en = $i18nCol->get('en__RG__contact');
-        $this->assertEquals('/contact', $en->getPattern());
+        $this->assertEquals('/contact', $this->getPattern($en));
     }
 
     public function testLoadAddsPrefix()
@@ -135,7 +146,7 @@ class I18nLoaderTest extends \PHPUnit_Framework_TestCase
         $i18nCol = $this->getLoader('prefix')->load($col);
 
         $en = $i18nCol->get('en__RG__dashboard');
-        $this->assertEquals('/admin/en/dashboard', $en->getPattern());
+        $this->assertEquals('/admin/en/dashboard', $this->getPattern($en));
     }
 
     public function getStrategies()

--- a/Translation/RouteTranslationExtractor.php
+++ b/Translation/RouteTranslationExtractor.php
@@ -26,6 +26,7 @@ use Symfony\Component\Routing\RouterInterface;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\ExtractorInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class RouteTranslationExtractor implements ExtractorInterface
 {
@@ -57,7 +58,13 @@ class RouteTranslationExtractor implements ExtractorInterface
             }
 
             $message = new Message($name, $this->domain);
-            $message->setDesc($route->getPattern());
+            // getPattern is deprecated since Symfony 2.2 and will be removed in 3.0. Use the getPath() message suppressed.
+            if (Kernel::VERSION > 2.2) {
+                $desc = $route->getPath();
+            } else {
+                $desc = $route->getPattern();
+            }
+            $message->setDesc($desc);
             $catalogue->add($message);
         }
 


### PR DESCRIPTION
Route's getPattern and setPattern methods were deprecated since symfony version 2.2 and these will be removed in symfony 3.0, fixed as backward compatible. fixed issue  schmittjoh/JMSI18nRoutingBundle#168