### PR TITLE
Set headers to disble cache on redirect response

### DIFF
--- a/EventListener/LocaleChoosingListener.php
+++ b/EventListener/LocaleChoosingListener.php
@@ -70,6 +70,15 @@ class LocaleChoosingListener
         $params = $request->query->all();
         unset($params['hl']);
 
-        $event->setResponse(new RedirectResponse($request->getBaseUrl().'/'.$locale.'/'.($params ? '?'.http_build_query($params) : '')));
+        $response = new RedirectResponse(
+            $request->getBaseUrl() . '/' . $locale . '/' . ($params ? '?'.http_build_query($params) : '')
+        );
+        $response->setPrivate();
+        $response->setMaxAge(0);
+        $response->setSharedMaxAge(0);
+        $response->headers->addCacheControlDirective('must-revalidate', true);
+        $response->headers->addCacheControlDirective('no-store', true);
+
+        $event->setResponse($response);
     }
 }


### PR DESCRIPTION
When I get redirected to a detected language I do not want the response to be cached. The present state correctly redirects for the first user, but the other users get the cached response.