### PR TITLE
Recognizing Another formats for languages

### DIFF
--- a/Router/DefaultLocaleResolver.php
+++ b/Router/DefaultLocaleResolver.php
@@ -41,7 +41,7 @@ class DefaultLocaleResolver implements LocaleResolverInterface
         if ($request->query->has('hl')) {
             $hostLanguage = $request->query->get('hl');
 
-            if (preg_match('#^[a-z]{2}(?:_[a-z]{2})?$#i', $hostLanguage)) {
+            if (preg_match('#^[a-z]{2}(?:[_-][a-z]{2})?$#i', $hostLanguage)) {
                 return $hostLanguage;
             }
         }
@@ -58,7 +58,7 @@ class DefaultLocaleResolver implements LocaleResolverInterface
         if ($request->cookies->has($this->cookieName)) {
             $hostLanguage = $request->cookies->get($this->cookieName);
 
-            if (preg_match('#^[a-z]{2}(?:_[a-z]{2})?$#i', $hostLanguage)) {
+            if (preg_match('#^[a-z]{2}(?:[_-][a-z]{2})?$#i', $hostLanguage)) {
                 return $hostLanguage;
             }
         }


### PR DESCRIPTION
In some cases there sites that use hyphen as locale separator, I believe that we can accept these formats too.

Ex.:
http://www.domain.com/en_US/
http://www.domain.com/en-US/
