### PR TITLE
Moving conditional statement, if the locale resolver was not able to determine a locale

### DIFF
--- a/Router/I18nRouter.php
+++ b/Router/I18nRouter.php
@@ -197,12 +197,12 @@ class I18nRouter extends Router
                 $currentLocale = $this->localeResolver->resolveLocale(
                     $request, $params['_locales']
                 );
-
-                // If the locale resolver was not able to determine a locale, then all efforts to
-                // make an informed decision have failed. Just display something as a last resort.
-                if (!$currentLocale) {
-                    $currentLocale = reset($params['_locales']);
-                }
+            }
+            
+            // If the locale resolver was not able to determine a locale, then all efforts to
+            // make an informed decision have failed. Just display something as a last resort.
+            if (!$currentLocale) {
+                $currentLocale = reset($params['_locales']);
             }
 
             if (!in_array($currentLocale, $params['_locales'], true)) {


### PR DESCRIPTION
Moving conditional statement. If the locale resolver was not able to determine a locale, then all efforts to make an informed decision have failed. Just display something as a last resort. Avoids a possible exception, if the requested language is an empty string - JMS\I18nRoutingBundle\Exception\NotAcceptableLanguageException: The requested language "" was not available.