### PR TITLE
Don't call Extension::addClassesToCompile() on php versions greater than 7

### DIFF
--- a/DependencyInjection/JMSI18nRoutingExtension.php
+++ b/DependencyInjection/JMSI18nRoutingExtension.php
@@ -46,9 +46,11 @@ class JMSI18nRoutingExtension extends Extension
         $container->setParameter('jms_i18n_routing.redirect_to_host', $config['redirect_to_host']);
         $container->setParameter('jms_i18n_routing.cookie.name', $config['cookie']['name']);
 
-        $this->addClassesToCompile(array(
-            $container->getDefinition('jms_i18n_routing.router')->getClass(),
-        ));
+        if (PHP_VERSION_ID < 70000) {
+            $this->addClassesToCompile(array(
+                $container->getDefinition('jms_i18n_routing.router')->getClass(),
+            ));
+        }
 
         if ('prefix' === $config['strategy']) {
             $container


### PR DESCRIPTION
This method is deprecated in 3.3. See https://github.com/symfony/symfony/pull/20735