### PR TITLE
Fixed tests for Symfony 3.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     fast_finish: true
 
 before_install:
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer self-update
   - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ cache:
 
 matrix:
     include:
-        - php: hhvm
+        - php: hhvm-3.15
+          dist: trusty
         - php: 5.4
         - php: 5.3
         - php: 5.5
@@ -17,9 +18,9 @@ matrix:
     fast_finish: true
 
 before_install:
-  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - if ! [[ "$TRAVIS_PHP_VERSION" == hhvm* ]]; then echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
   - composer self-update
-  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi;
+  - if ! [[ "$TRAVIS_PHP_VERSION" == hhvm* ]]; then phpenv config-rm xdebug.ini; fi;
 
 install:
   - composer install


### PR DESCRIPTION
I deliberately chose to use full namespaced class name for `Scope` and `RequestStack` as depending on which Symfony version the tests are run , they could not exist.

- `RequestStack` was introduced on Symfony 2.4
- `Scope` was removed on Symfony 3.0