### PR TITLE
The `router` alias is public

### DIFF
--- a/DependencyInjection/Compiler/SetRouterPass.php
+++ b/DependencyInjection/Compiler/SetRouterPass.php
@@ -30,7 +30,7 @@ class SetRouterPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $container->setAlias('router', 'jms_i18n_routing.router');
+        $container->setAlias('router', 'jms_i18n_routing.router')->setPublic(true);
 
         $translatorDef = $container->findDefinition('translator');
         if ('%translator.identity.class%' === $translatorDef->getClass()) {


### PR DESCRIPTION
This is fix #216