### PR TITLE
Improve readability i18nrouter constructor

### DIFF
--- a/Router/I18nRouter.php
+++ b/Router/I18nRouter.php
@@ -54,7 +54,7 @@ class I18nRouter extends Router
      */
     public function __construct()
     {
-        call_user_func_array(array('Symfony\Bundle\FrameworkBundle\Routing\Router', '__construct'), func_get_args());
+        parent::__construct(...func_get_args());
         $this->container = func_get_arg(0);
     }
 


### PR DESCRIPTION
Instead of calling the parent constructor via call_user_func, we can use `...` to unpack the arguments, which looks a bit cleaner.