### PR TITLE
[Fix] Changed localeChoosingListener on kernel request

### DIFF
--- a/DependencyInjection/JMSI18nRoutingExtension.php
+++ b/DependencyInjection/JMSI18nRoutingExtension.php
@@ -48,7 +48,7 @@ class JMSI18nRoutingExtension extends Extension
             $container
                 ->getDefinition('jms_i18n_routing.locale_choosing_listener')
                 ->setPublic(true)
-                ->addTag('kernel.event_listener', array('event' => 'kernel.exception', 'priority' => 128))
+                ->addTag('kernel.event_listener', array('event' => 'kernel.request', 'priority' => 128))
             ;
         }
 

--- a/EventListener/LocaleChoosingListener.php
+++ b/EventListener/LocaleChoosingListener.php
@@ -20,8 +20,7 @@ namespace JMS\I18nRoutingBundle\EventListener;
 
 use JMS\I18nRoutingBundle\Router\LocaleResolverInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
@@ -48,7 +47,7 @@ class LocaleChoosingListener
         $this->localeResolver = $localeResolver;
     }
 
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelRequest(GetResponseEvent $event)
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;
@@ -56,11 +55,6 @@ class LocaleChoosingListener
 
         $request = $event->getRequest();
         if ('' !== rtrim($request->getPathInfo(), '/')) {
-            return;
-        }
-
-        $ex = $event->getException();
-        if (!$ex instanceof NotFoundHttpException || !$ex->getPrevious() instanceof ResourceNotFoundException) {
             return;
         }
 


### PR DESCRIPTION
Type : [Fix] Problem with the welcome page on symfony 3.4.7

On symfony 3.4.7, the welcome page didn't throw an exception anymore (in debug mode). The localeChoosingListener has been put in kernel.request instead.