### PR TITLE
Document route translation without bundle

### DIFF
--- a/Resources/doc/usage.rst
+++ b/Resources/doc/usage.rst
@@ -9,8 +9,13 @@ routes to make them translatable.
 
 Translating Routes
 ------------------
-Once your code is stable enough to begin translation, you can use the ``translation:extract``
-command that is provided by JMSTranslationBundle_:
+
+Routes are translated in translation domain ``routes``, so in Symfony 4 you can create ``translations/routes.<locale>.yaml``. The translation key is the name of your route, so if your routes is named ``news.detail``, the translation key is also ``news.detail``.
+
+Integrating With JMSTranslationBundle_
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use the ``translation:extract`` command that is provided by JMSTranslationBundle_ to locate translations:
 
 .. code-block :: bash
 


### PR DESCRIPTION
The documentation only mentioned how to translate routes using `JMSTranslationBundle,` but if you don't use this bundle, you're left to your own devices for figuring out how to translate them. This adds a little explainer on how to proceed.