### PR TITLE
Replace GetResponseForExceptionEvent with ExceptionEvent (Symfony 5.x compatibility)

### DIFF
--- a/EventListener/LocaleChoosingListener.php
+++ b/EventListener/LocaleChoosingListener.php
@@ -20,7 +20,7 @@ namespace JMS\I18nRoutingBundle\EventListener;
 
 use JMS\I18nRoutingBundle\Router\LocaleResolverInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -48,7 +48,7 @@ class LocaleChoosingListener
         $this->localeResolver = $localeResolver;
     }
 
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelException(ExceptionEvent $event)
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;
@@ -59,7 +59,7 @@ class LocaleChoosingListener
             return;
         }
 
-        $ex = $event->getException();
+        $ex = $event->getThrowable();
         if (!$ex instanceof NotFoundHttpException || !$ex->getPrevious() instanceof ResourceNotFoundException) {
             return;
         }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "sensio/framework-extra-bundle": "*",
-        "symfony/symfony": "^4.0 || ^5.0",
+        "symfony/symfony": "^4.3 || ^5.0",
         "phpunit/phpunit": "^6.0"
     },
     "suggest": {


### PR DESCRIPTION
This PR replaces `GetResponseForExceptionEvent::getException()` with `ExceptionEvent::getThrowable()` since `GetResponseForExceptionEvent` has been removed from Symfony starting with Symfony 5.0.


I've also bumped requirements for version of Symfony to 4.3 since this is when `ExceptionEvent` class was introduced to Symfony. This shouldn't be an issue since `CookieSettingListener`is already using ResponseEvent that has been added to Symfony with v4.3 as well, this change was introduced in https://github.com/schmittjoh/JMSI18nRoutingBundle/pull/243