### PR TITLE
Fix deprecation with return type in `JMSI18nRoutingBundle::getContainerExtension`

### DIFF
--- a/JMSI18nRoutingBundle.php
+++ b/JMSI18nRoutingBundle.php
@@ -22,6 +22,7 @@ use JMS\I18nRoutingBundle\DependencyInjection\JMSI18nRoutingExtension;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use JMS\I18nRoutingBundle\DependencyInjection\Compiler\SetRouterPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -36,7 +37,7 @@ class JMSI18nRoutingBundle extends Bundle
         $container->addCompilerPass(new SetRouterPass());
     }
 
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new JMSI18nRoutingExtension();
     }


### PR DESCRIPTION
Fix deprecation notice in symfony 5.4.x

```
[14-Mar-2022 14:00:09 UTC] 2022-03-14T14:00:09+00:00 [info] User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension()" might add "?ExtensionInterface" as a native return type declaration in the future. Do the same in child class "JMS\I18nRoutingBundle\JMSI18nRoutingBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
```